### PR TITLE
feature/deckbuilder ux fixes

### DIFF
--- a/src/tempus-fugit-client/objects/game-gui-objects/card-visual-builder.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/card-visual-builder.ts
@@ -8,6 +8,17 @@ export type CardVisualBuildResult = {
     image: Phaser.GameObjects.Image;
 };
 
+function findTopLevelAndSplit(guiStr: string): number {
+    let depth = 0;
+    for (let i = 0; i < guiStr.length; i++) {
+        if (guiStr[i] === '(') depth++;
+        else if (guiStr[i] === ')') depth--;
+        else if (guiStr[i] === '&' && depth === 0)
+            return i;
+    }
+    return -1;
+}
+
 export function buildCardVisual(
     container: Phaser.GameObjects.Container,
     card: Card,
@@ -53,13 +64,13 @@ export function buildCardVisual(
 
     let margin = 2;
     let formulaString = card.getFormulaGuiString();
-    let formulaGUI;
+    const splitAfter = longFormula ? findTopLevelAndSplit(formulaString) : -1;
+    let formulaGUI: FormulaGUI;
     if (formulaString.length > 8) {
-        const maxWidth = Math.ceil(width / 0.8);
-        formulaGUI = new FormulaGUI(scene, formulaString, 0, 0, 0, false, true, maxWidth).setScale(0.8);
+        formulaGUI = new FormulaGUI(scene, formulaString, 0, 0, 0, false, true, splitAfter).setScale(0.8) as FormulaGUI;
         container.add(formulaGUI);
-        const charsPerRow = Math.floor(Math.ceil(width / 0.8) / 16);
-        formulaGUI.setPosition(-6.4 * Math.min(formulaString.length, charsPerRow), padding + 46 - height / 2);
+        const row1Len = splitAfter >= 0 ? splitAfter : formulaString.length;
+        formulaGUI.setPosition(-6.4 * row1Len, padding + 46 - height / 2);
     } else {
         formulaGUI = new FormulaGUI(scene, formulaString, 0, 0, margin, false);
         container.add(formulaGUI);

--- a/src/tempus-fugit-client/objects/game-gui-objects/card-visual-builder.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/card-visual-builder.ts
@@ -31,7 +31,8 @@ export function buildCardVisual(
     container.add(roundRect);
     container.sendToBack(roundRect);
 
-    [48, 78, 190].forEach((y) => {
+    const longFormula = card.getFormulaGuiString().length > 12;
+    (longFormula ? [48, 100, 210] : [48, 78, 190]).forEach((y) => {
         const line = scene.add.line(0, 0, 0, y - height / 2, width, y - height / 2, rectOutlineColor, 1);
         line.setLineWidth(2);
         container.add(line);
@@ -54,9 +55,11 @@ export function buildCardVisual(
     let formulaString = card.getFormulaGuiString();
     let formulaGUI;
     if (formulaString.length > 8) {
-        formulaGUI = new FormulaGUI(scene, formulaString, 0, 0, 0, false).setScale(0.8);
+        const maxWidth = Math.ceil(width / 0.8);
+        formulaGUI = new FormulaGUI(scene, formulaString, 0, 0, 0, false, true, maxWidth).setScale(0.8);
         container.add(formulaGUI);
-        formulaGUI.setPosition(-6 * formulaString.length, padding + 46 - height / 2);
+        const charsPerRow = Math.floor(Math.ceil(width / 0.8) / 16);
+        formulaGUI.setPosition(-6.4 * Math.min(formulaString.length, charsPerRow), padding + 46 - height / 2);
     } else {
         formulaGUI = new FormulaGUI(scene, formulaString, 0, 0, margin, false);
         container.add(formulaGUI);
@@ -88,13 +91,13 @@ export function buildCardVisual(
     if (typeof effectText.setLineSpacing === 'function') effectText.setLineSpacing(5);
     else effectText.lineSpacing = 5;
     effectText.setOrigin(0.5, 0);
-    effectText.setPosition(0, padding + 190 - height / 2);
+    effectText.setPosition(0, padding + (longFormula ? 210 : 190) - height / 2);
 
     let image = scene.add.image(0, 0, card.getImage());
     image.setDisplaySize(140, 115);
     container.add(image);
     image.setOrigin(0.5, 0);
-    image.setPosition(0, 75 - height / 2);
+    image.setPosition(0, (longFormula ? 97 : 75) - height / 2);
 
     let effectFontSize = 24;
     while (effectText.height > 100 && effectFontSize > 10) {

--- a/src/tempus-fugit-client/objects/game-gui-objects/formula-gui.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/formula-gui.ts
@@ -25,7 +25,7 @@ export class FormulaGUI extends Phaser.GameObjects.Container {
         margin: number,
         withRectangle: boolean,
         downscale:boolean=true,
-        maxWidth:number=0
+        splitAfter:number=-1
     ) {
         super(scene, x, y);
         this.scene = scene;
@@ -55,11 +55,12 @@ export class FormulaGUI extends Phaser.GameObjects.Container {
         const rowHeight = 26;
         this.elementList = [];
         const formulaWidth = (16 + margin) * (formulaString.length + 1);
-        for (let char of formulaString) {
-            if (maxWidth > 0 && pos + 16 > maxWidth) {
+        for (let i = 0; i < formulaString.length; i++) {
+            if (splitAfter >= 0 && i === splitAfter) {
                 pos = 0;
                 row++;
             }
+            const char = formulaString[i];
             this.elementList.push(this.scene.add.sprite(pos, row * rowHeight, this.reps[char].type, this.reps[char].frame));
             pos += step;
         }

--- a/src/tempus-fugit-client/objects/game-gui-objects/formula-gui.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/formula-gui.ts
@@ -24,7 +24,8 @@ export class FormulaGUI extends Phaser.GameObjects.Container {
         y: number,
         margin: number,
         withRectangle: boolean,
-        downscale:boolean=true
+        downscale:boolean=true,
+        maxWidth:number=0
     ) {
         super(scene, x, y);
         this.scene = scene;
@@ -49,11 +50,18 @@ export class FormulaGUI extends Phaser.GameObjects.Container {
         this.reps["("] = { type: "operators", frame: 13 };
         this.reps[")"] = { type: "operators", frame: 14 };
         let pos = 0;
+        let row = 0;
+        const step = 16 + margin;
+        const rowHeight = 26;
         this.elementList = [];
         const formulaWidth = (16 + margin) * (formulaString.length + 1);
         for (let char of formulaString) {
-            this.elementList.push(this.scene.add.sprite(pos, 0, this.reps[char].type, this.reps[char].frame));
-            pos += (16 + margin);
+            if (maxWidth > 0 && pos + 16 > maxWidth) {
+                pos = 0;
+                row++;
+            }
+            this.elementList.push(this.scene.add.sprite(pos, row * rowHeight, this.reps[char].type, this.reps[char].frame));
+            pos += step;
         }
         if (withRectangle) {
             this.graphics = this.scene.add.graphics();

--- a/src/tempus-fugit-client/objects/navigation-scene-objects/deck-builder.ts
+++ b/src/tempus-fugit-client/objects/navigation-scene-objects/deck-builder.ts
@@ -660,6 +660,7 @@ export class DeckBuilder {
         this.removeCardFromCardsViewer(card);
 
         let cardgui = this.createCard(card);
+        cardgui.setScale(1.75);
         cardgui.on("drag", function(pointer) {
             let obj = this.deckSlider.getElement("background");
             if (!Phaser.Geom.Rectangle.Contains(new Phaser.Geom.Rectangle(obj.x,obj.y,obj.width,obj.height)

--- a/src/tempus-fugit-client/objects/navigation-scene-objects/deck-builder.ts
+++ b/src/tempus-fugit-client/objects/navigation-scene-objects/deck-builder.ts
@@ -564,16 +564,27 @@ export class DeckBuilder {
         });
         label.layout();
 
-        label.setInteractive().on("pointerover", function(pointer) {
-            let obj = this.cardsSlider.getElement("background")
+        label.setInteractive().on("pointermove", function(pointer) {
+            if (this.dragging) return;
+            let obj = this.cardsSlider.getElement("background");
             if (!Phaser.Geom.Rectangle.Contains(new Phaser.Geom.Rectangle(obj.x,obj.y,obj.width,obj.height)
             , pointer.x, pointer.y)) return;
-            if (this.dragging) return;
-
             let drag = this.getDragCard(card);
-            drag.label = label;
-            drag.setPosition(pointer.x, pointer.y)
-            drag.setVisible(true);
+            const spriteBounds = sprite.getBounds();
+            const nameBounds = name.getBounds();
+            const hoverZone = new Phaser.Geom.Rectangle(
+                spriteBounds.left,
+                label.getBounds().top,
+                nameBounds.right - spriteBounds.left,
+                label.getBounds().height
+            );
+            if (hoverZone.contains(pointer.x, pointer.y)) {
+                drag.label = label;
+                drag.setPosition(pointer.x + 200, pointer.y);
+                drag.setVisible(true);
+            } else {
+                drag.setVisible(false);
+            }
         },this).on("pointerout", function(pointer) {
             if (this.dragging) return;
 

--- a/src/tempus-fugit-client/scenes/dialog-scene.ts
+++ b/src/tempus-fugit-client/scenes/dialog-scene.ts
@@ -19,6 +19,18 @@ export class DialogScene extends Scene {
         this.parentScene = data.parent;
         this.window = new DescritptionDialog(this, data.description, data.buttons, data.title);
 
+        const overlay = this.add.rectangle(
+            this.sys.canvas.width / 2,
+            this.sys.canvas.height / 2,
+            this.sys.canvas.width,
+            this.sys.canvas.height,
+            0x000000, 0
+        ).setInteractive().setDepth(999);
+        overlay.on("pointerdown", (pointer) => {
+            const bounds = this.window.dialog.getBounds();
+            if (!bounds.contains(pointer.x, pointer.y)) this.window.hide();
+        });
+
         this.scene.pause(this.parentScene);
         if (data.scene) data.scene.activeDialog = this.window;
         this.scene.bringToTop(this.scene.key);


### PR DESCRIPTION
- **feat: narrow hover zone to icon/name area and show preview to the right**
- **feat: scale deck cards to 1.75x to fill available space without overlap**
- **feat: wrap long card formulas to second line with correct spacing and centering**
- **Wrap long card formulas at top-level & operator**
- **Close tutorial dialog when clicking outside it**
