### PR TITLE
Make dark beam remove future light (and fix guiding light effect)

### DIFF
--- a/src/tempus-fugit-client/json/cards.json
+++ b/src/tempus-fugit-client/json/cards.json
@@ -167,7 +167,7 @@
 		{"name":"Dark beam",
 		"description":"Deals 50 {atk} to a foe but un-sets three {light}!",
 		"image":"dark_beam",
-		"formula":"(l|#Ol)<->t&s",
+		"formula":"G(l|n)&#Fs",
 		"cardKind":"directed",
 		"isStandCard":"false",
 		"standRounds":"3",
@@ -215,7 +215,7 @@
 		"cardKind":"player",
 		"isStandCard":"false",
 		"standRounds":"3",
-		"action":"mission.player.baseAttack+=2;mission.gameState.setAllVariableValues([{variable:'l', start:1, end:25, local:true, value:true}]);",
+		"action":"mission.player.baseAttack+=2;mission.gameState.setAllVariableValues([{variable:'l', start:1, end:-1, local:true, value:true}]);",
 		"comment":"Base attack up by 1 and: -> Gl",
 		"maxCardsInDeck":"2"},
 


### PR DESCRIPTION
Makes dark beam depend on `Future-globally light` and consume some future light. So, it can be played a lot after one of the cards that sets a light future (e.g. Guiding Light and Lightning Rain).

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ac3ed335-a9d6-4c63-b590-32b8de5d308d" />

The PR also fixes an index issue wich made Guiding Light not work as intended.

Closes #41 
