### PR TITLE
51 table gui seen states should also be evaluated by ltl operators

### DIFF
--- a/src/tempus-fugit-client/objects/game-gui-objects/table-gui.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/table-gui.ts
@@ -311,7 +311,10 @@ export class TableGUI implements GameStateListener {
     paddVariableStates(n: number) {
         const variableValues:any = {}
         for (let key in this.gameState.variables) {
-            variableValues[key] = { [ n ]: false };
+            const values = this.gameState.variables[key].values
+            if (n >= values.length) {
+                variableValues[key] = { [ n ]: false };
+            }
         }
 
         this.gameState.setVariableValues(

--- a/src/tempus-fugit-client/objects/game-gui-objects/table-gui.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/table-gui.ts
@@ -473,7 +473,7 @@ export class TableGUI implements GameStateListener {
         }
         this.tableColumnCount += n;
         this.variableTable.setItems(this.tableItems);
-        this.paddVariableStates(n);
+        this.paddVariableStates(this.tableColumnCount-1);
     }
 
     async variableChanged(gameState: GameState, oldVariable: Variable, variable: Variable, valueChanges: { [p: number]: boolean }) {

--- a/src/tempus-fugit-client/objects/game-gui-objects/table-gui.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/table-gui.ts
@@ -437,8 +437,8 @@ export class TableGUI implements GameStateListener {
 
     async roundChanged(gameSate: GameState, lastRound: number, activeRound: number) {
         // add 30 more columns if end of table is reached
-        if (activeRound >= this.tableColumnCount - 1) {
-            this.addColumns(30);
+        if (activeRound >= this.tableColumnCount - 3) {
+            this.addColumns(3);
         }
 
         // change color of coloumn
@@ -453,10 +453,7 @@ export class TableGUI implements GameStateListener {
         this.createEnergyTable(this.gameState.maxEnergy);
 
         // move table to the right if last visible column is reached
-        if ([20, 30, 40, 50, 60].includes(activeRound)) {
-            for (let i = 0; i < 10; i++)
-                this.scrollTable(true);
-        }
+        this.scrollTable(true)
     }
 
     addColumns(n: number) {

--- a/src/tempus-fugit-client/objects/game-gui-objects/table-gui.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/table-gui.ts
@@ -304,6 +304,19 @@ export class TableGUI implements GameStateListener {
         }).on("cell.out", function (cellContainer, cellIndex) {
             tooltips[cellIndex].fadeOut()
         })
+
+        this.paddVariableStates(this.tableColumnCount-1)
+    }
+
+    paddVariableStates(n: number) {
+        const variableValues:any = {}
+        for (let key in this.gameState.variables) {
+            variableValues[key] = { [ n ]: false };
+        }
+
+        this.gameState.setVariableValues(
+            variableValues, false
+        )
     }
 
     /**
@@ -460,6 +473,7 @@ export class TableGUI implements GameStateListener {
         }
         this.tableColumnCount += n;
         this.variableTable.setItems(this.tableItems);
+        this.paddVariableStates(n);
     }
 
     async variableChanged(gameState: GameState, oldVariable: Variable, variable: Variable, valueChanges: { [p: number]: boolean }) {


### PR DESCRIPTION
closes #51 
features:
- The variable state arrays and the shown states in the table gui should now match
- the current state is now padded by 3 variable states such that the current state should never be the last defined variable state

Screenshot:
<img width="1868" height="1024" alt="image" src="https://github.com/user-attachments/assets/505e94fe-ae99-4473-aebb-7fa32aee34f1" />

ignore here the health. It was increased for testing. On the right the states can be seen. Initially they have 20 defined values set to false