### PR TITLE
Fix a race where card destruction collided with tweens

### DIFF
--- a/src/tempus-fugit-client/objects/game-gui-objects/card-gui.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/card-gui.ts
@@ -65,6 +65,7 @@ export class CardGUI extends Phaser.GameObjects.Container {
        * don't call hover method of cardGUI objects; user this moethod implemented in handGUI
        */
     public hover(): void {
+        if (!this.active || !this.scene || !this.scene.tweens) return;
         this.setDepth(999);
 
         this.hoverTween = this.scene.tweens.add({
@@ -84,6 +85,7 @@ export class CardGUI extends Phaser.GameObjects.Container {
      * don't call unhover method of cardGUI objects; user this moethod implemented in handGUI
      */
     unhover(): void {
+        if (!this.active || !this.scene || !this.scene.tweens) return;
         this.setDepth(this.cardOriginZ);
         this.unhoverTween = this.scene.tweens.add({
             targets: this,

--- a/src/tempus-fugit-client/objects/game-gui-objects/hand-gui.ts
+++ b/src/tempus-fugit-client/objects/game-gui-objects/hand-gui.ts
@@ -84,7 +84,7 @@ export class HandGUI extends Phaser.GameObjects.Container implements HandListene
     toggleHovering(card: CardGUI, unhover: Boolean): void {
 
 
-        if (!this.cardGUIs.includes(card))
+        if (!this.canHoverCard(card))
             return;
 
         let allTweensDone = true;
@@ -98,6 +98,7 @@ export class HandGUI extends Phaser.GameObjects.Container implements HandListene
         if (!allTweensDone) {
             new Promise(resolve => setTimeout(resolve, 100))
                 .then(() => {
+                    if (!this.canHoverCard(card)) return;
                     self.unhoverAll();
                     if (!unhover)
                         card.hover()
@@ -107,8 +108,16 @@ export class HandGUI extends Phaser.GameObjects.Container implements HandListene
             this.unhoverAll();
 
             if (!unhover)
-                card.hover();
+                if (this.canHoverCard(card))
+                    card.hover();
         }
+    }
+
+    private canHoverCard(card: CardGUI): boolean {
+        return this.cardGUIs.includes(card)
+            && card.active
+            && !!card.scene
+            && !!card.scene.tweens;
     }
 
     /**
@@ -233,7 +242,7 @@ export class HandGUI extends Phaser.GameObjects.Container implements HandListene
             if (this.cardGUIs[pos].card === card) {
                 //console.log('removing card');
                 this.stack.addCard(this.cardGUIs[pos].card);
-                this.cardGUIs[pos].cross.destroy;
+                this.cardGUIs[pos].cross.destroy();
                 this.cardGUIs[pos].destroy();
                 this.cardGUIs.splice(parseInt(pos), 1);
                 this.arrangeCards(true);


### PR DESCRIPTION
When playing cards too quickly, I ran into the following error:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'tweens')
    at CardGUI.hover (card-gui.ts:43:38)
    at eval (hand-gui.ts:84:26)
```

Could not reproduce the error with these changes, but one cannot be quite sure due to the timing aspect.