### PR TITLE
reproducing bug from issue 43

### DIFF
--- a/src/tempus-fugit-client/tests/formula-test-data.ts
+++ b/src/tempus-fugit-client/tests/formula-test-data.ts
@@ -8,5 +8,27 @@ export default [
 		},
 		"evaluatedState":0,
 		"expected":true
-	}
+	},
+	{
+		"description":"Lightning Stand bug with full tables (see issue #43)",
+		"formula":"#Ol&l&#F(s&n)",
+		"states":{
+			"l":[0,1,0,1,1,1],
+			"s":[1,0,0,0,0,0],
+			"n":[1,0,0,0,0,0]
+		},
+		"evaluatedState":5,
+		"expected":true
+	},
+	{
+		"description":"Lightning Stand bug with lazy tables (see issue #43)",
+		"formula":"#Ol&l&#F(s&n)",
+		"states":{
+			"l":[0,1,0,1,1,1],
+			"s":[1],
+			"n":[1]
+		},
+		"evaluatedState":5,
+		"expected":true
+	},
 ]


### PR DESCRIPTION
"Lightning Stand bug with full tables" does not fail, however "Lightning Stand bug with lazy tables" does fail.